### PR TITLE
PHP Lints

### DIFF
--- a/composer.json.example
+++ b/composer.json.example
@@ -1,0 +1,24 @@
+{
+  "name": "mobomo/lints",
+  "description": "description",
+  "minimum-stability": "stable",
+  "license": "proprietary",
+  "authors": [
+    {
+      "name": "jason",
+      "email": "jason.murray@mobomo.com"
+    }
+  ],
+  "require-dev": {
+    "drupal/coder": "^8.3",
+    "jakub-onderka/php-console-highlighter": "^0.4.0",
+    "jakub-onderka/php-parallel-lint": "^1.0",
+    "squizlabs/php_codesniffer": "^3.5"
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    }
+  ]
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<ruleset name="mobomo">
+    <description>Base Mobomo PHP CS Lint Ruleset for Drupal</description>
+    <config name="ignore_warnings_on_exit" values="0"/>
+    <config name="ignore_errors_on_exit" value="0"/>
+
+    <arg name="ignore" value="*.css,*.md,*.txt,*.png,*.gif,*.jpeg,*.jpg,*.svg"/>
+    <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml"/>
+
+    <!-- Use colors in output. -->
+    <arg name="colors"/>
+    <!-- Show progress. -->
+    <arg value="ps"/>
+
+    <!-- Include existing standards. -->
+    <rule ref="./vendor/drupal/coder/coder_sniffer"/>
+
+    <rule ref="Drupal"/>
+    <rule ref="DrupalPractice">
+        <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
+    </rule>
+
+    <!-- Set file paths -->
+
+    <!-- Dockerstand paths -->
+    <!--    <file>docroot/modules/custom</file>-->
+    <!--    <file>docroot/themes/custom</file>-->
+
+    <!-- Landostand paths -->
+    <!--    <file>webroot/modules/custom</file>-->
+    <!--    <file>webroot/themes/custom</file>-->
+
+    <exclude-pattern>*/behat</exclude-pattern>
+    <exclude-pattern>*/node_modules</exclude-pattern>
+    <exclude-pattern>*/vendor</exclude-pattern>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,7 +13,8 @@
     <arg value="ps"/>
 
     <!-- Include existing standards. -->
-    <rule ref="./vendor/drupal/coder/coder_sniffer"/>
+        <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
+        <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice">


### PR DESCRIPTION
Adds a sample composer.json to include all options.

Add s simple phpcs.xml.dist file that provides basic configuration, and verbose warning and error reporting, as well as default paths for both dockerstand and landostand.