### PR TITLE
Update PHP Linting Config

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -1,0 +1,12 @@
+# Basic PHPCS configuration for use in Drupal projects.
+
+Coder 8.x will work on D9, D8 and D7 projects.  Coder package should not be installed for non-drupal projects and all references to it's rulesets should be removed from the `phpcs.xml.dist` file.
+
+By default, this provides a very verbose and noisy ruleset out of the box, applying all warning and weak warning rules as well as error rules to suggest best practices.  The ruleset applied can be tuned to the specific needs of the individual project by editing the `phpcs.xml.dist` file.
+
+## Setup
+* Copy the `phpcs.xml.dist` file into your project.
+* Edit the project's composer.json file to include the packages listed in `composer.json.example`.
+* Run composer to install the new packages.
+* Edit the `phpcs.xml.dist` file to include the proper paths for your project, examples are included for Dockerstand and Landostand based projects.
+* From the project root, run `./vendor/bin/phpcs` to sniff and generate the report.

--- a/PHP/README.md
+++ b/PHP/README.md
@@ -1,4 +1,4 @@
-# Basic PHPCS configuration for use in Drupal projects.
+# Basic PHPCS configuration for use in PHP/Drupal projects.
 
 Coder 8.x will work on D9, D8 and D7 projects.  Coder package should not be installed for non-drupal projects and all references to it's rulesets should be removed from the `phpcs.xml.dist` file.
 

--- a/PHP/phpcs.xml.dist
+++ b/PHP/phpcs.xml.dist
@@ -1,25 +1,32 @@
 <?xml version="1.0"?>
 <ruleset name="mobomo">
-    <description>Base Mobomo PHP CS Lint Ruleset for Drupal</description>
-    <config name="ignore_warnings_on_exit" values="0"/>
-    <config name="ignore_errors_on_exit" value="0"/>
+  <description>Base Mobomo PHP CS Lint Ruleset for Drupal</description>
 
-    <arg name="ignore" value="*.css,*.md,*.txt,*.png,*.gif,*.jpeg,*.jpg,*.svg"/>
-    <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml"/>
+  <config name="ignore_warnings_on_exit" value="0"/>
+  <config name="ignore_errors_on_exit" value="0"/>
+  <config name="show_warnings" value="0"/>
 
-    <!-- Use colors in output. -->
-    <arg name="colors"/>
-    <!-- Show progress. -->
-    <arg value="ps"/>
+  <!-- Uncomment this line to suppress warnings and best practices -->
+  <!--  <arg name="warning-severity" value="0"/> -->
 
-    <!-- Include existing standards. -->
-        <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
-        <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+  <arg name="ignore" value="*.css,*.md,*.txt,*.png,*.gif,*.jpeg,*.jpg,*.svg"/>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml"/>
 
-    <rule ref="Drupal"/>
-    <rule ref="DrupalPractice">
-        <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
-    </rule>
+  <!-- Use colors in output. -->
+  <arg name="colors"/>
+  <!-- Show progress. -->
+  <arg value="ps"/>
+
+  <!-- Include existing standards. -->
+  <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
+  <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
+
+  <rule ref="Drupal">
+    <exclude name="Drupal.Files.LineLength.TooLong"/>
+  </rule>
+  <rule ref="DrupalPractice">
+    <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
+  </rule>
 
     <!-- Set file paths -->
 


### PR DESCRIPTION
Updates the PHPCS config to add warnings and weak-warnings by default to help with best practices.  Adds README.md to provide basic setup instruction and notes.